### PR TITLE
Adding co-op's password policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@
             <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></td>
           </tr>
           <tr>
-            <td>Cooperative Bank</td>
+            <td>Co-operative Bank</td>
             <td><a href="https://www.co-operativebank.co.nz">www.co-operativebank.co.nz</a></td>
-            <td><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></td>
+            <td><span class="glyphicon glyphicon-minus" aria-hidden="true"></span><sup><a href="#note9">[9]</a></sup></td>
             <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></td>
             <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></td>
             <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></td>
@@ -159,6 +159,7 @@
         <p id="note6">[6] TSB were unwilling to publicise their password requirements, if you bank with TSB and could check that would be great</p>
         <p id="note7">[7] Westpac passwords are case insensitive (!!!?). <a href="http://westpac.custhelp.com/app/answers/detail/a_id/523/~/how-do-i-choose-an-online-banking-password%3F">source</a></p>
         <p id="note8">[8] The <a href="http://www.gcsb.govt.nz/publications/the-nz-information-security-manual/">NZ Information Security Manual (NZISM)</a> part 2 section 16.1.21.C.01. requires passwords to be at least 10 characters, allowing lower and upper case, digits, and special characters.</p>
+        <p id="note9">[9] Co-operative bank's passworld policy requires passwords to be between 8-15 characters, containing at least 1 number and 1 letter. <a href="https://www.co-operativebank.co.nz/terms-and-conditions/terms-and-conditions-digital-services">source</a></p>
 
       </div>
 


### PR DESCRIPTION
Co-op bank's password policy publicly is:

> your Password is a minimum of 8 and a maximum of 15 characters, with at least one number and one letter;

They also have some stuff around PINs which might be worth reviewing.
